### PR TITLE
fix: registerAsync was not allowing imports

### DIFF
--- a/lib/module.ts
+++ b/lib/module.ts
@@ -34,6 +34,7 @@ export class MailmanModule {
     return {
       global: true,
       module: MailmanModule,
+      imports: options.imports || [],
       providers: [MailmanService, this.createStorageOptionsProvider(options)],
     };
   }


### PR DESCRIPTION
when trying to register the module using the sync function i get this error:
```
Nest can't resolve dependencies of the MAILABLE_OPTIONS (?). Please make sure that the argument ConfigService at index [0] is available in the MailmanModule context.
```
after some debugging it became obvious that the module was not importing the `ConfigModule` because it was never being passed in the first place.

This fix allows imports to be passed down and fix the error mentioned. currently the module is completely unusable for those who want to follow the async way without this fix.