### PR TITLE
feat: enable secure connection on port 465

### DIFF
--- a/lib/service.ts
+++ b/lib/service.ts
@@ -14,6 +14,7 @@ export class MailmanService {
       {
         host: options.host,
         port: options.port,
+        secure: options.port === 465 ? true : false,
         auth: { user: options.username, pass: options.password },
       },
       { from: options.from }


### PR DESCRIPTION
enabling secure connection for port 465 as per nodemailer docs https://nodemailer.com/smtp/#tls-options