### PR TITLE
add ignoreTls option to work with maildev

### DIFF
--- a/lib/service.ts
+++ b/lib/service.ts
@@ -14,6 +14,7 @@ export class MailmanService {
       {
         host: options.host,
         port: options.port,
+        ignoreTLS: options.ignoreTLS,
         auth: { user: options.username, pass: options.password },
       },
       { from: options.from }


### PR DESCRIPTION
For development proposal we can use [maildev](https://github.com/maildev/maildev) , to allow that we must set nodemailer.transport.ignoreTLS=true, 

 
![image](https://user-images.githubusercontent.com/83643707/130883225-9b40347e-352a-4524-ae55-b579addd7ae3.png)


ps:  perhaps its good update the documentation or some interface/contract, this pr was made github web ui :smile_cat:   

Nice work :+1: 

